### PR TITLE
Fix error handling

### DIFF
--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './login.component';
-import { LoginGuard } from './login.guard';
+import { LoginComponentGuard } from './login.guard';
+import { MainComponentGuard } from './login.guard';
 import { MainComponent } from './main.component';
 
 const routes: Routes = [
-  { path: 'login', component: LoginComponent },
-  { path: '', component: MainComponent, canActivate: [LoginGuard] },
+  { path: 'login', component: LoginComponent, canActivate: [LoginComponentGuard] },
+  { path: '', component: MainComponent, canActivate: [MainComponentGuard] },
 ];
 
 @NgModule({

--- a/web/src/app/login.component.ts
+++ b/web/src/app/login.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { CookieService } from 'ngx-cookie';
 import { Router } from '@angular/router';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SessionService } from './session.service';
+import { SessionService, SessionAlreadyOpenError } from './session.service';
 
 class LoginDialogResult {
   name: string = '';
@@ -105,6 +105,10 @@ export class LoginComponent implements OnInit {
         .then(() => this.router.navigate(['/']))
         .catch(err => {
           alert(err);
+          if (err instanceof SessionAlreadyOpenError) {
+            this.router.navigate(['/']);
+            return;
+          }
           this.openLoginDialog();
         });
     });

--- a/web/src/app/login.component.ts
+++ b/web/src/app/login.component.ts
@@ -104,7 +104,12 @@ export class LoginComponent implements OnInit {
         .joinSession(result.sessionId, result.name)
         .then(() => this.router.navigate(['/']))
         .catch(err => {
-          alert(err);
+          if (err instanceof Error) {
+            alert("Failed to join session: " + err.message);;
+          }
+          else {
+            alert("Failed to join session");
+          }
           if (err instanceof SessionAlreadyOpenError) {
             this.router.navigate(['/']);
             return;

--- a/web/src/app/login.guard.ts
+++ b/web/src/app/login.guard.ts
@@ -6,7 +6,7 @@ import { SessionService } from './session.service';
 @Injectable({
   providedIn: 'root'
 })
-export class LoginGuard implements CanActivate {
+export class LoginComponentGuard implements CanActivate {
   constructor(
     private router: Router,
     private sessionService: SessionService,
@@ -14,7 +14,29 @@ export class LoginGuard implements CanActivate {
 
   canActivate(
     route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (this.sessionService.session() == null) {
+      return true;
+    } else {
+      return this.router.parseUrl('/');
+    }
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MainComponentGuard implements CanActivate {
+  constructor(
+    private router: Router,
+    private sessionService: SessionService,
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     if (this.sessionService.session() == null) {
       return this.router.parseUrl('/login');
     } else {

--- a/web/src/app/main.component.ts
+++ b/web/src/app/main.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { SessionService, Session, SessionState, UserState } from './session.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-main',
@@ -49,24 +50,35 @@ import { SessionService, Session, SessionState, UserState } from './session.serv
     ':host { padding: 8px 16px; display: block; }',
   ],
 })
-export class MainComponent {
+export class MainComponent implements OnDestroy {
   session: Session | null = null;
   cards: string[] = ["0", "1", "2", "3", "5", "8", "13", "20", "40", "60", "100", "?", "☕"];
   points: string | null = null;
   spectator: boolean = false;
+  subscriptions: Subscription[] = [];
 
   constructor(
     private sessionService: SessionService,
     private router: Router,
   ) {
-    sessionService.session$.subscribe((session: Session | null) => {
-      this.session = session;
-      if (this.session === null) {
-        this.router.navigate(['/login']);
+    this.subscriptions.push(sessionService.session$.subscribe(
+      (session: Session | null) => {
+        this.session = session;
+        if (this.session === null) {
+          this.router.navigate(['/login']);
+        }
       }
-    });
-    sessionService.error$.subscribe((err: Error) => {
-      alert(err);
+    ));
+    this.subscriptions.push(sessionService.error$.subscribe(
+      (err: Error) => {
+        alert(err);
+      }
+    ));
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach((subscription) => {
+      subscription.unsubscribe();
     });
   }
 

--- a/web/src/app/session.service.ts
+++ b/web/src/app/session.service.ts
@@ -165,13 +165,15 @@ export class SessionService {
           }
         }
       },
-      (err: Error) => {
-        console.log("Got update error: " + JSON.stringify(err));
-        this.leaveSessionWithError(err);
+      (errorEvent: Event) => {
+        const message = "Connection closed due to an error";
+        console.log(message);
+        this.leaveSessionWithError(new Error(message));
       },
       () => {
-        console.log("Updates completed");
-        this.leaveSessionWithError(new Error("Connection closed"));
+        const message = "Connection closed by server";
+        console.log(message);
+        this.leaveSessionWithError(new Error(message));
       }
     );
   }

--- a/web/src/app/session.service.ts
+++ b/web/src/app/session.service.ts
@@ -24,6 +24,9 @@ export class UserState {
   isSpectator: boolean = false;
 }
 
+export class SessionAlreadyOpenError extends Error {
+}
+
 class Message {
   tag: string = '';
   content: any = null;
@@ -67,7 +70,7 @@ export class SessionService {
 
   public async joinSession(sessionId: string, name: string): Promise<void> {
     if (this.session() != null) {
-      throw new Error("Already joined to a session");
+      throw new SessionAlreadyOpenError("Already joined to a session");
     }
 
     // Open websocket. Not using rxjs WebSocketSubject here since it displays

--- a/web/src/app/session.service.ts
+++ b/web/src/app/session.service.ts
@@ -82,10 +82,10 @@ export class SessionService {
         resolve();
       };
       this.webSocket!.onerror = (event) => {
-        reject();
+        reject(new Error("connection error"));
       };
       this.webSocket!.onclose = (event) => {
-        reject();
+        reject(new Error("connection closed"));
       };
     });
 


### PR DESCRIPTION
This fixes several issues related to error handling:

* Fix error with already joined session: This fixes a situation where the login fails with the error "Already joined to a session" but the user is kept on the login page.
* Add mechanism to prevent users from navigating back to the login screen.
* Provide more information why the websocket connection was closed (closed by remote or closed because of an error).
* Use correct error type in case of websocket errors. The correct type is `Event` (not `Error`).
* Unsubscribe `MainComponent` on destruction from `SessionService`. This avoids that errors are reported multiple times.
* Improve error message when websocket fails to connect. Before this, I only got "undefined".
* React to websocket errors early (before setting up session details).