### PR TITLE
Rejoin session

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicI64;
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::Error as WebSocketError;
 
 pub struct Session {
     ctx: Arc<ServiceContext>,
@@ -133,13 +134,27 @@ impl Session {
         });
 
         // Listen to messages from the connection.
-        if let Err(err) = self.handle_connection(conn, &user_id).await {
+        let connection_result = self.handle_connection(conn, &user_id).await;
+        if let Err(ref err) = connection_result {
             log::warn!("Session::join/handle_connection: {}", err);
         }
+        let websocket_protocol_error_occurred = match connection_result {
+            Err(ref err) => err.chain().any(|cause| {
+                matches!(
+                    cause.downcast_ref::<WebSocketError>(),
+                    Some(WebSocketError::Protocol(_))
+                )
+            }),
+            _ => false,
+        };
 
         // Remove user from state.
         self.update_state(|mut state| {
-            state.users.remove(&user_id);
+            if websocket_protocol_error_occurred {
+                state.users.get_mut(&user_id).unwrap().is_stale = true;
+            } else {
+                state.users.remove(&user_id);
+            }
             if state.admin.as_ref() == Some(&user_id) {
                 state.admin = None;
             }
@@ -147,11 +162,20 @@ impl Session {
         })
         .await?;
 
-        log::info!(
-            "Session::join: User {} leaving session \"{}\"",
-            user_id,
-            self.session_id
-        );
+        if websocket_protocol_error_occurred {
+            log::info!(
+                "Session::join: User {} in session \"{}\" is stale",
+                user_id,
+                self.session_id
+            );
+        } else {
+            log::info!(
+                "Session::join: User {} leaving session \"{}\"",
+                user_id,
+                self.session_id
+            );
+        }
+
         Ok(())
     }
 
@@ -166,10 +190,36 @@ impl Session {
             let result = match msg? {
                 ClientMessage::NameChange(name) if name.len() <= 32 => {
                     self.update_state(|mut state| {
+                        let mut stale_duplicates: HashMap<String, UserState> = HashMap::new();
+                        state.users.retain(|other_user_id, other_user| {
+                            if other_user.name.as_ref() == Some(&name) && other_user.is_stale {
+                                stale_duplicates.insert(other_user_id.clone(), other_user.clone());
+                                false
+                            }
+                            else {
+                                true
+                            }
+                        });
                         if state.users.values().all(|user| user.name.as_ref() != Some(&name)) {
-                            state.users.get_mut(user_id).unwrap().name = Some(name.clone());
+                            assert!(stale_duplicates.len() <= 1);
+                            match stale_duplicates.iter().next() {
+                                Some((other_user_id, other_user)) => {
+                                    log::info!(
+                                        "Session::join: User {} takes over stale user {} in session \"{}\"",
+                                        user_id,
+                                        other_user_id,
+                                        self.session_id
+                                    );
+                                    state.users.insert(user_id.to_string(), other_user.clone());
+                                    state.users.get_mut(user_id).unwrap().is_stale = false;
+                                }
+                                None => {
+                                    state.users.get_mut(user_id).unwrap().name = Some(name.clone());
+                                }
+                            };
                             Ok(state)
                         } else {
+                            assert!(stale_duplicates.len() == 0);
                             Err(PlancError::DuplicateName.into())
                         }
                     })
@@ -291,6 +341,7 @@ pub struct UserState {
     pub name: Option<String>,
     pub points: Option<String>,
     pub is_spectator: bool,
+    pub is_stale: bool,
     #[serde(skip)]
     pub kicked: bool,
 }

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -12,8 +12,10 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { MatToolbarModule} from '@angular/material/toolbar';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { NgModule } from '@angular/core';
+import { ReconnectDialogComponent } from './main.component';
 
 @NgModule({
   declarations: [
@@ -21,6 +23,7 @@ import { NgModule } from '@angular/core';
     LoginComponent,
     LoginDialogComponent,
     MainComponent,
+    ReconnectDialogComponent,
   ],
   imports: [
     AppRoutingModule,
@@ -33,6 +36,7 @@ import { NgModule } from '@angular/core';
     MatDialogModule,
     MatIconModule,
     MatInputModule,
+    MatProgressSpinnerModule,
     MatToolbarModule,
     FormsModule,
   ],

--- a/web/src/app/login.component.ts
+++ b/web/src/app/login.component.ts
@@ -99,6 +99,14 @@ export class LoginComponent implements OnInit {
       disableClose: true,
     });
     dialogRef.afterClosed().subscribe(result => {
+      // An empty result shouldn't be possible, but on Microsoft Edge this
+      // happens (for whatever reason) when the server is shut down while a
+      // session was open.
+      if (!result) {
+        this.openLoginDialog();
+        return;
+      }
+
       this.saveLoginDialogResult(result);
       this.sessionService
         .joinSession(result.sessionId, result.name)

--- a/web/src/app/login.guard.ts
+++ b/web/src/app/login.guard.ts
@@ -16,10 +16,11 @@ export class LoginComponentGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    if (this.sessionService.session() == null) {
-      return true;
-    } else {
+    if (this.sessionService.connected()) {
       return this.router.parseUrl('/');
+    }
+    else {
+      return true;
     }
   }
 }
@@ -37,9 +38,10 @@ export class MainComponentGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    if (this.sessionService.session() == null) {
+    if (!this.sessionService.connected()) {
       return this.router.parseUrl('/login');
-    } else {
+    }
+    else {
       return true;
     }
   }

--- a/web/src/app/main.component.ts
+++ b/web/src/app/main.component.ts
@@ -34,6 +34,7 @@ export class ReconnectDialogComponent {
           <span *ngIf="!revealCards() && user.value.points != null">: x</span>
         </span>
         <span *ngIf="user.value.isSpectator">: Spectator</span>
+        <span *ngIf="user.value.isStale"> (stale)</span>
       </li>
     </ul>
     <div *ngIf="displayCards() && !spectator">

--- a/web/src/app/session.service.ts
+++ b/web/src/app/session.service.ts
@@ -23,6 +23,7 @@ export class UserState {
   name: string | null = null;
   points: number | null = null;
   isSpectator: boolean = false;
+  isStale: boolean = false;
 }
 
 export class SessionAlreadyOpenError extends Error {


### PR DESCRIPTION
* The first commit only provides functionality to easily reconnect if the websocket connection was dropped.
* The second commit treats websocket errors on the server side special by not removing the respective user but marking him/her as "stale". This allows to keep the user's state (especially already voted points) after reconnecting.