### PR TITLE
Fix logic error that prevented points from being revealed correctly

### DIFF
--- a/web/src/context/SessionControlProvider.tsx
+++ b/web/src/context/SessionControlProvider.tsx
@@ -85,9 +85,11 @@ export default function SessionControlProvider({ children }: SessionControlProvi
   let numNonSpectators = 0;
   for (const uid in sessionState?.users) {
     const user = sessionState.users[uid];
-    if (user.points === null && !user.isSpectator) {
-      revealPoints = false;
+    if (!user.isSpectator) {
       numNonSpectators += 1;
+      if (user.points === null) {
+        revealPoints = false;
+      }
     }
   }
   if (numNonSpectators === 0) {


### PR DESCRIPTION
The number of spectators was counted incorrectly which led to `revealPoints` not flipping to true when it should have.